### PR TITLE
Test routes with invalid jwt

### DIFF
--- a/test/helpers/index.test.js
+++ b/test/helpers/index.test.js
@@ -2,6 +2,7 @@ const expect = require('chai').expect;
 const Chance = require('chance');
 
 // local imports
+const logger = require('../../config/logger');
 const { extractToken } = require('../../helpers');
 
 describe('Test Helper Functions', () => {

--- a/test/routes/entities.test.js
+++ b/test/routes/entities.test.js
@@ -29,6 +29,8 @@ describe('Test Entity Routes', () => {
 
   describe('Entities', () => {
     before(function () {
+      // disable logging
+      logger.silent = true;
       nock(postgrestUrls.entities, {
         reqheaders: {
           'Authorization': `Bearer ${token}`
@@ -54,6 +56,8 @@ describe('Test Entity Routes', () => {
 
   describe('Entity Schema', () => {
     before(function () {
+      // disable logging
+      logger.silent = true;
       nock(postgrestUrls.entities, {
         reqheaders: {
           'Authorization': `Bearer ${token}`
@@ -106,6 +110,11 @@ describe('Test Entity Routes', () => {
 
       expect(res._isJSON()).to.be.true;
       expect(res._getData()).to.equal(JSON.stringify({"message": expectedMessage}));
+    });
+
+    after(function () {
+      // enable logging
+      logger.silent = false;
     });
   });
 

--- a/test/routes/items.test.js
+++ b/test/routes/items.test.js
@@ -15,17 +15,19 @@ describe('Test Item Routes', () => {
   before(function () {
     // disable logging
     logger.silent = true;
+  });
+
+  it('Should return an item', async () => {
+    // mock http request
     nock(postgrestUrls.entities, {
       reqheaders: {
         'Authorization': `Bearer ${token}`
       }
     })
-    .persist()
     .intercept('/', 'GET').reply(200, entitiesResponse)
     .intercept('/country?id=eq.3', 'GET').reply(200, itemResponse)
-  });
 
-  it('Should return an item', async () => {
+    // mock request and response objects
     const req = httpMocks.createRequest({
       method: 'GET',
       url: '/v1/entities/country/items/3',
@@ -54,9 +56,41 @@ describe('Test Item Routes', () => {
     expect(res._getData()).to.equal(JSON.stringify({"message": expectedMessage}));
   });
 
+  it('Should return "401 Unauthorized" when retrieving an item with an expired token', async () => {
+    // mock http request
+    nock(postgrestUrls.entities, {
+      reqheaders: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+    .intercept('/', 'GET').reply(401, {'message': 'JWT expired'})
+    .intercept('/country?id=eq.3', 'GET').reply(401, {'message': 'JWT expired'})
+
+    // mock request and response objects
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      url: '/v1/entities/country/items/3',
+      headers: {'authorization': `Bearer ${token}`},
+      params: {'name': 'country', 'id': 3}
+    });
+    const res = httpMocks.createResponse();
+    const expectedData = {"code":401,"status":null,"data":"JWT expired"};
+    await getItem(req, res);
+
+    expect(res._isJSON()).to.be.true;
+    expect(res._getData()).to.equal(JSON.stringify(expectedData));
+  });
+
   after(function () {
     // enable logging
     logger.silent = false;
-  })
+  });
+
+  afterEach(function () {
+    // ensure that unused nock interceptors are not left behind
+    if (!nock.isDone()) {
+      nock.cleanAll();
+    }
+  });
 });
 

--- a/test/services/entities.test.js
+++ b/test/services/entities.test.js
@@ -22,6 +22,11 @@ describe('Test Entity Services', () => {
   });
 
   describe('Entities', () => {
+    before(function () {
+      // disable logging
+      logger.silent = true;
+    });
+
     it('Returns all entities', (done) => {
       nock(postgrestUrls.entities, {
         reqheaders: {
@@ -54,9 +59,19 @@ describe('Test Entity Services', () => {
         done();
       })
     });
+
+    after(function () {
+      // enable logging
+      logger.silent = false;
+    });
   });
 
   describe('Entity', () => {
+    before(function () {
+      // disable logging
+      logger.silent = true;
+    });
+
     it('Returns an entity by name', async () => {
       const name = 'activities';
       nock(postgrestUrls.entities, {
@@ -86,6 +101,11 @@ describe('Test Entity Services', () => {
 
       let data = await getEntityData(token, name);
       expect(data).to.deep.equal({'code': 401, 'status': null, 'data': 'JWT expired'});
+    });
+
+    after(function () {
+      // enable logging
+      logger.silent = false;
     });
   });
 

--- a/test/services/items.test.js
+++ b/test/services/items.test.js
@@ -32,7 +32,7 @@ describe('Test Item Services', () => {
     expect(data).to.deep.equal(itemFormattedData);
   });
 
-  it('Should return 401 Unauthorized for expired tokens', async () => {
+  it('Should return 401 Unauthorized when retrieving an item with an expired token', async () => {
     const name = 'country';
     const id = 3;
     const token = new Chance().hash();
@@ -52,5 +52,12 @@ describe('Test Item Services', () => {
   after(function () {
     // enable logging
     logger.silent = false;
+  });
+
+  afterEach(function () {
+    // ensure that unused nock interceptors are not left behind
+    if (!nock.isDone()) {
+      nock.cleanAll();
+    }
   });
 });


### PR DESCRIPTION
* Rename tests description;
* Added "401 Unauthorized" tests for expired tokens
* Add functionality to clean nock interceptors after each test, this will ensure that the next test will not be affected by previously left unused interceptor
