### PR TITLE
Add schema mode filtering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "prefer-const": "off",
     "consistent-return": "off",
     "prefer-destructuring": "off",
+    "no-loop-func": "off",
   },
   "extends": "airbnb/base",
   "env": {

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To have a local copy of the reference data you can run the following which will 
 ```bash
 docker network create db
 docker network create web
-KEYCLOAK_URL=http://keycloak.lodev.xyz/auth/realms/dev KEYCLOAK_CLIENT_ID=refdata-api PUBLIC_REFDATA_FLYWAY=/Users/XXX/GIT/cop/RefData PRIVATE_REFDATA_FLYWAY=/Users/XXX/GIT/cop/private_refdata docker-compose up -d
+KEYCLOAK_URL=http://keycloak.lodev.xyz/auth/realms/dev KEYCLOAK_CLIENT_ID=refdata-api PUBLIC_REFDATA_FLYWAY=/Users/XXX/GIT/cop/RefData PRIVATE_REFDATA_FLYWAY=/Users/XXX/GIT/cop/private_refdata docker-compose up
 docker logs public_refdata_flyway -f
 ```
 
@@ -148,4 +148,45 @@ To clean up the running instance and take it down run:
 
 ```bash
 docker-compose rm -vs
+```
+
+## Filtering examples
+Return all users where names match 'John' and 'Debbie'
+```bash
+filter=name=in.(John, Debbie)
+```
+
+Return all countries where names match 'Denmark', and 'Portugal'
+```bash
+filter=name=in.(Denmark, Portugal)
+```
+
+Return all users where name matches 'John'
+```bash
+filter=name=eq.John
+```
+
+Return all users where name is not equal to 'John'
+```bash
+filter=name=neq.John
+```
+
+Return user where name is 'John' and email is 'john@mail.com'
+```bash
+filter=name=eq.John&filter=email=eq.john@mail.com
+```
+
+Return only the entity schema
+```bash
+mode=schemaOnly
+```
+
+Return only the entity data
+```bash
+mode=dataOnly
+```
+
+Return only the entity data where user name matches 'John'
+```bash
+mode=dataOnly&filter=name=eq.John
 ```

--- a/app/db/utils.js
+++ b/app/db/utils.js
@@ -60,4 +60,75 @@ function queryFilterDecode(queryParams) {
   return queryFilter.replace('&', ' AND ');
 }
 
-module.exports = queryFilterDecode;
+function queryFilterDecodeV2(queryParams) {
+  let queryFilter = '';
+
+  for (const key in queryParams) {
+    if (Object.prototype.hasOwnProperty.call(queryParams, key)) {
+      let field = '';
+      let filter = '';
+      let value = '';
+
+      if (key === 'filter') {
+        queryParams[key].map((params) => {
+          // 'id=eq.3' -> ['id', 'eq' '3']
+          params = params.replace('=', '|').replace('.', '|').split('|');
+          field = params[0];
+          filter = params[1];
+          value = params[2];
+          let isNull = false;
+
+          if (filter !== 'in' && isNaN(value) && value !== 'null') {
+            value = `'${value}'`;
+          } else if (isNaN(value) && value === 'null') {
+            isNull = true;
+            value = value.toUpperCase();
+          }
+
+          if (filter === 'gt' && !isNull) {
+            // 'sum IS GREATER THAN \'3\''
+            filter = '>';
+          } else if (filter === 'gte' && !isNull) {
+            // 'sum IS GREATER THAN or EQUAL to \'3\''
+            filter = '>=';
+          } else if (filter === 'lt' && !isNull) {
+            // 'sum IS LESS THAN \'3\''
+            filter = '<';
+          } else if (filter === 'lte' && !isNull) {
+            // 'sum IS LESS THAN or EQUAL to \'3\''
+            filter = '<=';
+          } else if (filter === 'eq' && !isNull) {
+            // 'continent = \'Asia\''
+            filter = '=';
+          } else if (filter === 'eq' && isNull) {
+            // 'validfrom IS NULL'
+            filter = 'IS';
+          } else if (filter === 'neq' && !isNull) {
+            // 'continent != \'Asia\''
+            filter = '!=';
+          } else if (filter === 'neq' && isNull) {
+            // 'validfrom IS NOT NULL'
+            filter = 'IS NOT';
+          } else {
+            filter = 'IN';
+            value = value.replace('%28', '').replace('%29', '').replace(/%20/g, ' ');
+
+            const values = value.split(',');
+            value = values.map(val => val.trim());
+            value = `'${value.join("', '")}'`;
+            value = `(${value})`;
+          }
+
+          queryFilter += `${field} ${filter} ${value}`;
+          queryFilter = queryFilter.replace(/%20/g, ' ');
+        });
+      }
+    }
+  }
+  return queryFilter.replace('&', ' AND ');
+}
+
+module.exports = {
+  queryFilterDecode,
+  queryFilterDecodeV2,
+};

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -9,6 +9,7 @@ const config = require('../config/core');
 const health = require('./health');
 const logger = require('../config/logger')(__filename);
 const v1 = require('./v1');
+const v2 = require('./v2');
 
 const app = express();
 const corsConfiguration = {
@@ -59,6 +60,7 @@ app.use((req, res, next) => {
 });
 
 app.use('/v1', v1);
+app.use('/v2', v2);
 app.get('/_health', health);
 
 module.exports = app;

--- a/app/routes/v2/index.js
+++ b/app/routes/v2/index.js
@@ -1,0 +1,10 @@
+const express = require('express');
+
+// local imports
+const entities = require('../entities');
+
+const app = express();
+
+app.get('/entities/:name', entities.getEntityV2);
+
+module.exports = app;

--- a/test/db/utils.test.js
+++ b/test/db/utils.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 
 // local imports
-const queryFilterDecode = require('../../app/db/utils');
+const { queryFilterDecode } = require('../../app/db/utils');
 
 describe('Test Database Utils', () => {
   describe('queryFilterDecode', () => {


### PR DESCRIPTION
Implements functionality to filter by schema using the filter `mode`
This functionality is only available for the API version 2.
Example: `http://localhost:5000/v2/<table_name>?mode=dataOnly`

Tested with:
```
http://localhost:5000/v2/entities/country?mode=dataOnly&filter=id=eq.1
# SELECT * FROM country WHERE id = 1;
```
Returns only the data